### PR TITLE
Fix MAC generation compatibility with older Perl versions

### DIFF
--- a/plugin/Plugin.pm
+++ b/plugin/Plugin.pm
@@ -28,7 +28,6 @@ my $prefs = preferences('plugin.groups');
 my $serverPrefs = preferences('server');
 
 $prefs->init({
-	lastID => int ( rand(2**32) ),
 	restoreStatic => 1,
 });
 

--- a/plugin/Settings.pm
+++ b/plugin/Settings.pm
@@ -76,11 +76,15 @@ sub handler {
 
 sub addGroup {
 	my ($name) = @_;
-	my $lastID = $prefs->get('lastID') + 1;
 
-	$prefs->set('lastID', $lastID);
-
-	my $id = sprintf("10:10:%02hhx:%02hhx:%02hhx:%02hhx", $lastID >> 24, $lastID >> 16, $lastID >> 8, $lastID);
+	my $id;
+	
+	my $genMAC = sub {
+		sprintf("10:10:%02x:%02x:%02x:%02x", int(rand(255)), int(rand(255)), int(rand(255)), int(rand(255)));
+	};
+	
+	# generate MAC address and verify it doesn't exist yet
+	while ( $groups{$id = $genMAC->()} ) {};
 
 	$groups{$id}->{'name'} = $name;
 	$groups{$id}->{'syncPower'} = 1;


### PR DESCRIPTION
The sprintf expression used is not available in Perl 5.12(?) and older. Replace with simpler method. Make generation state-less, but check for conflicts. Might be a tad bit more expensive, but that doesn't really matter here.