### PR TITLE
Fix showDisconnected handling in settings page

### DIFF
--- a/plugin/Settings.pm
+++ b/plugin/Settings.pm
@@ -63,7 +63,6 @@ sub handler {
 	}
 
 	$params->{newGroupName} = undef;
-	$params->{players}      = makePlayerList($params->{pref_showDisconnected});
 	$params->{groups}      = [ Plugins::Groups::Plugin::allPrefs ];
 	
 	$log->debug("Groups::Settings->handler() done.");
@@ -89,8 +88,10 @@ sub createId {
 	return $id;
 }
 
-sub makePlayerList {
-	my $showDisconnected = shift;
+sub beforeRender {
+	my ($class, $params, $client) = @_;
+
+	my $showDisconnected = $prefs->get('showDisconnected');
 	my @playerList = ();
 	
 	if ($showDisconnected) {
@@ -113,7 +114,7 @@ sub makePlayerList {
 	
 	@playerList = sort { lc($a->{'name'}) cmp lc($b->{'name'}) } @playerList;
 	
-	return \@playerList;
+	$params->{players} = \@playerList;
 }
 
 


### PR DESCRIPTION
The old code would read pref_showDisconnected. This value wouldn't be the current value when the page is first loaded, as it's only set when the page is submitted. We therefore have to read the pref directly from the prefs. Alas upon page submission that pref would still be the old value.

Introduce the beforeRender method: "A sub called before the page is rendered, but after the prefs have been processed/saved" (from Slim::Web::Settings). Exactly what we need here to set that pref.