### PR TITLE
Try to override the LMS Default web UI to provide a Group group in th…

### DIFF
--- a/plugin/HTML/Default/js-main-grouping.js
+++ b/plugin/HTML/Default/js-main-grouping.js
@@ -1,0 +1,96 @@
+if (SqueezeJS.UI.Buttons.PlayerDropdown) {
+	[% PROCESS jsString id='PLUGIN_GROUPS_NAME' jsId='choose_group' %]
+	
+	Ext.override(SqueezeJS.UI.Buttons.PlayerDropdown, {
+		_addPlayerlistMenu: function(response){
+			if (response.players_loop) {
+				response.players_loop = response.players_loop.sort(this._sortPlayer);
+				var specialItems = {};
+	
+				for (var x=0; x < response.players_loop.length; x++) {
+					var playerInfo = response.players_loop[x];
+					
+					if (!playerInfo.connected)
+						continue;
+	
+					// mark the current player as selected
+					if (playerInfo.playerid == SqueezeJS.Controller.getPlayer()) {
+						this.setText(playerInfo.name);
+					}
+	
+					// add the players to the list to be displayed in the synch dialog
+					this.playerList.add(playerInfo.playerid, {
+						name: playerInfo.name,
+						isplayer: playerInfo.isplayer
+					});
+	
+					var tpl = new Ext.Template( '<div>{title}<span class="browsedbControls"><img src="' + webroot + 'html/images/{powerImg}.gif" id="{powerId}">&nbsp;<img src="' + webroot + 'html/images/{playPauseImg}.gif" id="{playPauseId}"></span></div>')
+					
+					var menuItem = new Ext.menu.CheckItem({
+						text: tpl.apply({
+							title: playerInfo.name,
+							playPauseImg: playerInfo.isplaying ? 'b_pause' : 'b_play',
+							playPauseId: playerInfo.playerid + ' ' + (playerInfo.isplaying ? 'pause' : 'play'),
+							powerImg: playerInfo.power ? 'b_poweron' : 'b_poweroff',
+							powerId: playerInfo.playerid + ' power ' + (playerInfo.power ? '0' : '1')
+						}),
+						value: playerInfo.playerid,
+						cls: playerInfo.model,
+						group: 'playerList',
+						checked: playerInfo.playerid == playerid,
+						hideOnClick: false,
+						listeners: {
+							click: function(self, ev) {
+								var target = ev ? ev.getTarget() : null;
+								
+								// check whether user clicked one of the playlist controls
+								if ( target && Ext.id(target).match(/^([a-f0-9:]+ (?:power|play|pause)\b.*)/i) ) {
+									var cmd = RegExp.$1.split(' ');
+									
+									Ext.Ajax.request({
+										url: SqueezeJS.Controller.getBaseUrl() + '/jsonrpc.js',
+										method: 'POST',
+										params: Ext.util.JSON.encode({
+											id: 1,
+											method: "slim.request",
+											params: [cmd.shift(), cmd]
+										}),
+										callback: function() {
+											SqueezeJS.Controller.updateAll();
+										}
+									});
+									return false;
+								}
+							}
+						},
+						scope: this,
+						handler: this._selectPlayer
+					});
+				
+					// if a string "choose_MODEL" is defined, create separate group for this model
+					console.log(playerInfo.model)
+					if (playerInfo.model == 'group') {
+						if (!specialItems[playerInfo.model])
+							specialItems[playerInfo.model] = [];
+						
+						specialItems[playerInfo.model].push(menuItem);
+					}
+					else {
+						this.menu.add(menuItem);
+					}
+				}
+				
+				Ext.iterate(specialItems, function(key, value) {
+					this.menu.add(
+						'-',
+						'<span class="menu-title">' + SqueezeJS.string('choose_' + key) + '</span>'
+					);
+	
+					Ext.each(value, function(menuItem) {
+						this.menu.add(menuItem);
+					}, this);
+				}, this);
+			}
+		}
+	});
+}

--- a/plugin/Plugin.pm
+++ b/plugin/Plugin.pm
@@ -67,7 +67,18 @@ sub initPlugin {
 	if ( main::WEBUI ) {
 		require Plugins::Groups::Settings;
 		Plugins::Groups::Settings->new;
-	}	
+		
+		# try to add the Group Player section in the player selection drop-down menu - requires a recent 7.9.1 or later
+		eval {
+			require Slim::Web::Pages::JS;
+
+			Slim::Web::Pages->addPageFunction("plugins/groups/js-main-grouping.js", sub {
+				Slim::Web::HTTP::filltemplatefile('js-main-grouping.js', $_[1]);
+			});
+			
+			Slim::Web::Pages::JS->addJSFunction('js-main', 'plugins/groups/js-main-grouping.js');		
+		}
+	}
 
 	$class->initCLI();
 		


### PR DESCRIPTION
…e player selector

I applied a change to the latest 7.9 which allows adding JS to the main web UI. This change to the Groups plugin would override the player selector in the Default web UI to put groups in their own section of the UI.

If the server didn't support the feature yet, it would silently fail. As it's a minor tweak to the UI I didn't want users to get confused by an "error" in the log file. Feel free to change.