### PR TITLE
As it took me a moment to understand your implementation of "intersec…

### DIFF
--- a/plugin/Player.pm
+++ b/plugin/Player.pm
@@ -61,7 +61,7 @@ sub formats {
 	}
 		
 	# no attempt to create group done w/o codec
-	return @$codecs;
+	return @{ $codecs || [] };
 } 
 
 sub new {

--- a/plugin/Player.pm
+++ b/plugin/Player.pm
@@ -46,22 +46,22 @@ sub chunks { [] }
 
 sub formats { 
 	my $self = shift;
-	my @codecs;
+	my $codecs;		# use listref to distinguish undefined from empty
 		
 	foreach ( @{$prefs->client($self)->get('members') || []} )	{
 		my $member = Slim::Player::Client::getClient($_) || next;
 
-		if (!scalar @codecs) {
-			@codecs = $member->formats;
+		if (!defined $codecs) {
+			$codecs = [ $member->formats ];
 			next;
 		}		
 		
 		my %formats = map { $_ => 1 } $member->formats;
-		@codecs = grep { $formats{$_} } @codecs;
+		$codecs = [ grep { $formats{$_} } @$codecs ];
 	}
 		
 	# no attempt to create group done w/o codec
-	return @codecs;
+	return @$codecs;
 } 
 
 sub new {


### PR DESCRIPTION
…tion", I decided to be a smart ass again :-).

- no need to filter the initial codecs list
- create a hash of the member's codecs, to be used in the grep filter expression

This doesn't change anything about the result, but is easier to read in my eyes.

Other than that thanks for having me read List::Util again. I totally forgot about its features.